### PR TITLE
Use generic package module

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
   user: name=kafka group=kafka system=true
 
 - name: install numactl
-  apt:
+  package:
     name: numactl
     state: present
 


### PR DESCRIPTION
We should be using the generic [package module](https://docs.ansible.com/ansible/latest/modules/package_module.html) here for better compatibility. This will allow the playbook to run on RHEL without changes (it'll auto-detect between yum and apt).