### PR TITLE
Update ansible-galaxy metadata

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
 
   license: Apache
 
-  min_ansible_version: 1.2
+  min_ansible_version: 2.6
 
   platforms:
   - name: EL

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,6 +18,7 @@ galaxy_info:
 
   galaxy_tags:
   - kafka
+  - humio
 
 dependencies:
   - role: humio.java

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,7 +13,8 @@ galaxy_info:
     - 7
   - name: Ubuntu
     version:
-      - bionic
+    - xenial
+    - bionic
 
   galaxy_tags:
   - kafka


### PR DESCRIPTION
Fixed a few things in the metadata:

* Increased minimum ansible version to 2.6 (lower than that won't work due to `dict2items` usage in the playbooks)
* Added Ubuntu Xenial to the list of supported platforms.
* Added an additional tag.