### PR TITLE
Don't download the tarball every run

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ Including an example of how to use your role (for instance, with variables passe
     - role: humio.kafka
 ```
 
+Troubleshooting
+---------------
+
+If you're forced to interrupt the ansible run during the `Install Kafka from remote` step, you may run into a situation
+where the tarball that's being fetched and unarchived was interrupted during the unarchive phase. If this step is
+interrupted while the tarball is still being fetched (e.g., a timeout), then you're fine to simply re-run the playbook
+again. If it happens during the unarchive phase, you will need to manually clear the
+`/usr/lib/kafka_{{ kafka_scala_version }}-{{ kafka_version }}` directory before running the playbook again (this stage
+checks for the existance of that directory to skip the step in future runs). 
+
 License
 -------
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,7 @@
     src: "{{ kafka_mirror }}/{{ kafka_version }}/kafka_{{ kafka_scala_version }}-{{ kafka_version }}.tgz"
     dest: "/usr/lib/"
     remote_src: yes
+    creates: "/usr/lib/kafka_{{ kafka_scala_version }}-{{ kafka_version }}"
   when: kafka_mirror != 'master'
 
 - name: Install Kafka from master


### PR DESCRIPTION
This will cause the tarball fetch to be skipped if the unarchived directory already exists. There could be some scenarios where the unarchive isn't fully completed and you would have to delete the directory to get it to actually fetch and unarchive again, but that will likely happen pretty rarely compared to the time savings of not fetching the tarball and unarchiving on every run.