### PR TITLE
Make sure Kafka keeps trying to restart

### DIFF
--- a/templates/kafka.service.j2
+++ b/templates/kafka.service.j2
@@ -2,7 +2,7 @@
   Description=Kafka Service
 
 [Service]
-  Restart=always
+  Restart=on-failure
   RestartSec=3
   LimitNOFILE=800000
   Environment="LOG_DIR=/var/log/kafka"

--- a/templates/kafka.service.j2
+++ b/templates/kafka.service.j2
@@ -2,7 +2,8 @@
   Description=Kafka Service
 
 [Service]
-  Restart=on-abnormal
+  Restart=always
+  RestartSec=3
   LimitNOFILE=800000
   Environment="LOG_DIR=/var/log/kafka"
   Environment="GC_LOG_ENABLED=true"


### PR DESCRIPTION
This is meant to fix an issue where Kafka fails to start on many nodes after a cluster is rebooted. Zookeeper already uses these restart settings and it comes up fine, but kafka doesn't and then Humio fails to boot due to kafka being down.