### PR TITLE
Add support for kafka broker.rack config

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ kafka_listeners:
   host: "{{ ansible_default_ipv4.address }}"
   port: 9092
 kafka_broker_id: 0
+kafka_broker_rack: dc1
 zookeeper_hosts:
 - ip: "{{ ansible_default_ipv4.address }}"
 ```
@@ -29,6 +30,16 @@ On machines without internet access `kafka_mirror` can be set to `"master"` to c
 ```yaml
 kafka_mirror: "master"
 ```
+
+Rack Awareness
+------------
+
+Kafka supports rack awareness if you specify which rack each Kafka node is in. This can be done by
+setting the `broker.rack` setting in Kafka. This is configured in this Ansible role via the
+`kafka_broker_rack` variable. To have this work properly, make sure each rack or datacenter is
+defined as a group in your inventory and the appropriate machines are assigned. You can then either
+set the `kafka_broker_rack` variable directly inside the inventory or you can create a `group_vars`
+file for each of the rack/datacenter groups that defines it appropriately.
 
 Dependencies
 ------------

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ defined as a group in your inventory and the appropriate machines are assigned. 
 set the `kafka_broker_rack` variable directly inside the inventory or you can create a `group_vars`
 file for each of the rack/datacenter groups that defines it appropriately.
 
+By default, all Kafkas are assigned to a single rack named `dc1`.
+
 Dependencies
 ------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ kafka_listeners:
   host: "{{ ansible_default_ipv4.address }}"
   port: 9092
 kafka_broker_id: 0
+kafka_broker_rack: dc1
 kafka_log_dirs: "/var/kafka/data"
 
 kafka_filebeat_fields: {}

--- a/templates/server.properties.j2
+++ b/templates/server.properties.j2
@@ -1,5 +1,6 @@
 #jinja2: trim_blocks:False
 broker.id={{ kafka_broker_id }}
+broker.rack={{ kafka_broker_rack }}
 zookeeper.connect={% for host in zookeeper_hosts -%}{{ host.ip }}:{{ host.port | default('2181') }}{% if not loop.last %},{% endif %}{%- endfor %}
 listeners={% for listener in kafka_listeners -%}{{ listener.scheme | default('PLAINTEXT') }}://{{ listener.host | default('') }}:{{ listener.port | default('9092') }}{% if not loop.last %}, {% endif %}{%- endfor %}
 replica.fetch.max.bytes=104857600


### PR DESCRIPTION
This allows you to specify which rack a Kafka belongs to so that partition assignment functions can operate in a rack-aware fashion.