### PR TITLE
Make role numa node aware

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: recollect facts
+  setup: ~
+  listen: Collect facts
+
 - name: Restart Kafka SystemD service
   service:
     name: kafka

--- a/tasks/custom_facts.yml
+++ b/tasks/custom_facts.yml
@@ -13,6 +13,8 @@
       for socket in $(/usr/bin/lscpu --all --parse=node,socket | grep -E "[0-9]$" | cut -d, -f2 | sort | uniq); do
         echo "[$socket]"
         echo "nodes="$(/usr/bin/lscpu --all --parse=node,socket | grep -E "${socket}$" | cut -d, -f1 | sort -n | uniq | paste -sd ',' -)
+        echo "nodes="$(/usr/bin/lscpu --all --parse=node,socket | grep -E "${socket}$" | cut -d, -f1 | sort -n |
+          uniq | paste -sd ',' -)
         echo
       done
     dest: "/etc/ansible/facts.d/numanodes.fact"

--- a/tasks/custom_facts.yml
+++ b/tasks/custom_facts.yml
@@ -5,19 +5,18 @@
     state: "directory"
   check_mode: no
 
-- name: NUMA node fact
+- name: Kafka NUMA node fact
   copy:
     content: |
       #!/bin/bash
       export LC_ALL=en_GB.UTF8
       for socket in $(/usr/bin/lscpu --all --parse=node,socket | grep -E "[0-9]$" | cut -d, -f2 | sort | uniq); do
         echo "[$socket]"
-        echo "nodes="$(/usr/bin/lscpu --all --parse=node,socket | grep -E "${socket}$" | cut -d, -f1 | sort -n | uniq | paste -sd ',' -)
         echo "nodes="$(/usr/bin/lscpu --all --parse=node,socket | grep -E "${socket}$" | cut -d, -f1 | sort -n |
           uniq | paste -sd ',' -)
         echo
       done
-    dest: "/etc/ansible/facts.d/numanodes.fact"
+    dest: "/etc/ansible/facts.d/kafka_numanodes.fact"
     mode: "0755"
   check_mode: no
   notify: Collect facts

--- a/tasks/custom_facts.yml
+++ b/tasks/custom_facts.yml
@@ -1,0 +1,15 @@
+---
+- name: NUMA node fact
+  copy:
+    content: |
+      #!/bin/bash
+      export LC_ALL=en_GB.UTF8
+      for socket in $(/usr/bin/lscpu --all --parse=node,socket | grep -E "[0-9]$" | cut -d, -f2 | sort | uniq); do
+        echo "[$socket]"
+        echo "nodes="$(/usr/bin/lscpu --all --parse=node,socket | grep -E "${socket}$" | cut -d, -f1 | sort -n | uniq | paste -sd ',' -)
+        echo
+      done
+    dest: "/etc/ansible/facts.d/numanodes.fact"
+    mode: "0755"
+  check_mode: no
+  notify: Collect facts

--- a/tasks/custom_facts.yml
+++ b/tasks/custom_facts.yml
@@ -1,4 +1,10 @@
 ---
+- name: Create Ansible facts directory
+  file:
+    path: "/etc/ansible/facts.d"
+    state: "directory"
+  check_mode: no
+
 - name: NUMA node fact
   copy:
     content: |

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+- import_tasks: custom_facts.yml
+
 - name: create kafka group
   group: name=kafka system=true
 - name: create kafka user

--- a/templates/kafka.service.j2
+++ b/templates/kafka.service.j2
@@ -8,9 +8,10 @@
   Environment="LOG_DIR=/var/log/kafka"
   Environment="GC_LOG_ENABLED=true"
   Environment="KAFKA_HEAP_OPTS=-Xms512M -Xmx4G"
+  Environment="NUMA_NODES={{ ansible_local.numanodes["0"].nodes }}"
   User=kafka
   Group=kafka
-  ExecStart=/usr/bin/numactl --cpunodebind=0 --membind=0 /usr/lib/kafka/bin/kafka-server-start.sh /etc/kafka/server.properties
+  ExecStart=/usr/bin/numactl --cpunodebind=${NUMA_NODES} --membind=${NUMA_NODES} /usr/lib/kafka/bin/kafka-server-start.sh /etc/kafka/server.properties
 
 [Install]
   WantedBy=default.target

--- a/templates/kafka.service.j2
+++ b/templates/kafka.service.j2
@@ -8,7 +8,7 @@
   Environment="LOG_DIR=/var/log/kafka"
   Environment="GC_LOG_ENABLED=true"
   Environment="KAFKA_HEAP_OPTS=-Xms512M -Xmx4G"
-  Environment="NUMA_NODES={{ ansible_local.numanodes["0"].nodes }}"
+  Environment="NUMA_NODES={{ ansible_local.kafka_numanodes["0"].nodes }}"
   User=kafka
   Group=kafka
   ExecStart=/usr/bin/numactl --cpunodebind=${NUMA_NODES} --membind=${NUMA_NODES} /usr/lib/kafka/bin/kafka-server-start.sh /etc/kafka/server.properties


### PR DESCRIPTION
This adds the same logic that's used to assign numa nodes in the main humio role to the kafka role. It is currently hard-coded to use the numa nodes associated with the first socket on multi-socket systems.