### PR TITLE
Force fact collection to happen immediately

### DIFF
--- a/tasks/custom_facts.yml
+++ b/tasks/custom_facts.yml
@@ -20,3 +20,6 @@
     mode: "0755"
   check_mode: no
   notify: Collect facts
+
+- name: Force Kafka fact collection to happen immediately
+  meta: flush_handlers


### PR DESCRIPTION
This fixes a failure that occurred on the first run. The numa node fact file would get written out and notify for a fact recollection, but that didn't happen until after the systemd unit file was being written out. At that point, the handler hadn't run yet so the fact wasn't available. If you ran again, it would be fine because the fact file was already in place. This change forces the handler to run immediately when the file is created or modified.