### PR TITLE
Expose JMX opts for Kakfa service

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ kafka_listeners:
 kafka_broker_id: 0
 kafka_broker_rack: dc1
 kafka_log_dirs: "/var/kafka/data"
+kafka_jmx_opts: "-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false "
 
 kafka_filebeat_fields: {}
 kafka_filebeat_tags: []

--- a/templates/kafka.service.j2
+++ b/templates/kafka.service.j2
@@ -9,6 +9,7 @@
   Environment="GC_LOG_ENABLED=true"
   Environment="KAFKA_HEAP_OPTS=-Xms512M -Xmx4G"
   Environment="NUMA_NODES={{ ansible_local.kafka_numanodes["0"].nodes }}"
+  Environment="KAFKA_JMX_OPTS={{ kafka_jmx_opts }}"
   User=kafka
   Group=kafka
   ExecStart=/usr/bin/numactl --cpunodebind=${NUMA_NODES} --membind=${NUMA_NODES} /usr/lib/kafka/bin/kafka-server-start.sh /etc/kafka/server.properties


### PR DESCRIPTION
This exposes the default kafka jmx opts so they may be overridden. The flags that are the value for `kafkfa_jmx_opts` are the same as what is defined in the java-run-class.sh script that kafka-server-start.sh runs.