### PR TITLE
Add kafka_log_dir and rename kafka_log_dirs to kafka_data_log_dir

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,17 @@ kafka_listeners:
   port: 9092
 kafka_broker_id: 0
 kafka_broker_rack: dc1
+
+# legacy variable used to specify data directory. use kafka_data_log_dir instead.
 kafka_log_dirs: "/var/kafka/data"
+
+# this is the data directory. it's defaulting to kafka_log_dirs to maintain compatibility with
+# older versions. this name change is being done to improve clarity.
+kafka_data_log_dir: "{{ kafka_log_dirs }}"
+
+# this is the service log directory (not to be confused with the data log directory specified above).
+kafka_log_dir: "/var/log/kafka"
+
 kafka_jmx_opts: "-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false "
 
 kafka_filebeat_fields: {}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,9 +54,9 @@
     group: kafka
     mode: 0755
 
-- name: Create data directories
+- name: Create data directory
   file:
-    path: "{{ kafka_log_dirs }}"
+    path: "{{ kafka_data_log_dir }}"
     state: directory
     owner: kafka
     group: kafka

--- a/templates/kafka.service.j2
+++ b/templates/kafka.service.j2
@@ -5,7 +5,7 @@
   Restart=on-failure
   RestartSec=3
   LimitNOFILE=800000
-  Environment="LOG_DIR=/var/log/kafka"
+  Environment="LOG_DIR={{ kafka_log_dir }}"
   Environment="GC_LOG_ENABLED=true"
   Environment="KAFKA_HEAP_OPTS=-Xms512M -Xmx4G"
   Environment="NUMA_NODES={{ ansible_local.kafka_numanodes["0"].nodes }}"

--- a/templates/server.properties.j2
+++ b/templates/server.properties.j2
@@ -6,7 +6,11 @@ listeners={% for listener in kafka_listeners -%}{{ listener.scheme | default('PL
 replica.fetch.max.bytes=104857600
 message.max.bytes=104857600
 compression.type=producer
-log.dirs={{ kafka_log_dirs }}
+
+# This is the data directory. The service log directory is specified
+# in the systemd unit file.
+log.dirs={{ kafka_data_log_dir }}
+
 log.retention.hours=48
 log.retention.check.interval.ms=300000
 unclean.leader.election.enable=false


### PR DESCRIPTION
This adds a new `kafka_log_dir` variable to allow easy modification of where Kafka service logs are stashed. It also adds a new variable named `kafka_data_log_dir` that defaults to the original `kafka_log_dirs` value. This is being done to make the names a bit clearer (really annoying that kafka named their data directory config setting `log.dirs`). Hopefully, this will make what the setting is for a bit clearer.