### PR TITLE
Pick up controller and state change logs from Kafka, in addition to t…

### DIFF
--- a/templates/filebeat.yml.j2
+++ b/templates/filebeat.yml.j2
@@ -2,6 +2,8 @@
 - type: log
   paths:
   - /var/log/kafka/server.log
+  - /var/log/kafka/controller.log
+  - /var/log/kafka/state-change.log
   fields:
     "@type": 'kafka'
     {% for field in kafka_filebeat_fields|dict2items -%}


### PR DESCRIPTION
…he server log.

These logs contain information regarding partition leadership changes.
The state change log contains state changes such as change in in-sync replicas, or new leaders for partitions.
The controller log contains log relating to why the controller decided to make a state change.